### PR TITLE
fix(mod): add stub for mock package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ clean-coverage:
 
 .PHONY: clean-mocks
 clean-mocks:
-	rm -rf mocks
+	rm -r mocks/build_info.go mocks/configurator.go
 
 coverage.out: $(shell find $(REPO_ROOT_DIR) -type f -name '*'.go)
 coverage.out: generate.host

--- a/mocks/stub.go
+++ b/mocks/stub.go
@@ -1,0 +1,3 @@
+//
+
+package mocks


### PR DESCRIPTION
`go mod tidy` downloads everything needed to run `go test all`. Since we
do not commit generated code, this breaks in the discovery since there
is no `mocks` package.