### PR TITLE
feat(context): add `ContextWithNameAndValues` helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ func HandleUser(ctx context.Context, userID string) {
     ctx = golflog.ContextWithValues(ctx, "user_id", userID)
 }
 ```
+
+The name and values can be setup together in one shot:
+```golang
+func HandleUser(ctx context.Context, userID string) {
+    ctx = golflog.ContextWithNameAndValues(ctx, "Queue", "user_id", userID)
+}
+```
+
 Funcitons are guaranteed to be able to get a logger from any context:
 ```golang
 func randoFunc(ctx context.Context) {

--- a/context.go
+++ b/context.go
@@ -74,6 +74,15 @@ func ContextWithValues(ctx context.Context, keysAndValues ...interface{}) contex
 	return NewContext(ctx, AlwaysFromContext(ctx).WithValues(keysAndValues...))
 }
 
+// ContextWithNameAndValues returns a context with the name and values set in its logger.
+func ContextWithNameAndValues(
+	ctx context.Context,
+	name string,
+	keysAndValues ...interface{},
+) context.Context {
+	return ContextWithName(ContextWithValues(ctx, keysAndValues...), name)
+}
+
 // WithName returns a context and logger with the given `name` set in the context.
 func WithName(ctx context.Context, name string) (context.Context, logr.Logger) {
 	newCtx := ContextWithName(ctx, name)
@@ -88,9 +97,14 @@ func WithValues(ctx context.Context, keysAndValues ...interface{}) (context.Cont
 	return newCtx, AlwaysFromContext(newCtx)
 }
 
-// WithNameAndValues returns a context and logger with the given `name` and `values` set in the context.
-func WithNameAndValues(ctx context.Context, name string, keysAndValues ...interface{}) (context.Context, logr.Logger) {
-	newCtx := ContextWithName(ContextWithValues(ctx, keysAndValues...), name)
+// WithNameAndValues returns a context and logger with the given `name` and `values` set in the
+// context.
+func WithNameAndValues(
+	ctx context.Context,
+	name string,
+	keysAndValues ...interface{},
+) (context.Context, logr.Logger) {
+	newCtx := ContextWithNameAndValues(ctx, name, keysAndValues...)
 
 	return newCtx, AlwaysFromContext(newCtx)
 }

--- a/context_test.go
+++ b/context_test.go
@@ -181,6 +181,24 @@ func TestContextWithValues(t *testing.T) {
 	suite.Run(t, new(ContextWithValuesSuite))
 }
 
+type ContextWithNameAndValuesSuite struct {
+	suite.Suite
+}
+
+func (suite *ContextWithNameAndValuesSuite) TestContextWithNameAndValues() {
+	cleanup, buf := monkeyPatchFallback()
+	defer cleanup(suite.T())
+
+	ctx := golflog.ContextWithNameAndValues(context.TODO(), "test", "testkey", "testval")
+
+	golflog.Info(ctx, "test")
+	suite.Equal(`test "level"=0 "msg"="test" "testkey"="testval"`+"\n", buf.String())
+}
+
+func TestContextWithNameAndValues(t *testing.T) {
+	suite.Run(t, new(ContextWithNameAndValuesSuite))
+}
+
 type NewContextSuite struct {
 	suite.Suite
 }


### PR DESCRIPTION
Allows setting up both the name and values and only returning the context.