### PR TITLE
feat(log): add helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,33 @@ func randoFunc(ctx context.Context) {
 }
 ```
 
+A `Warn` helper will automatically prepend `severity=warning` to the list of
+key/value pairs and logs out the message. This helper should be used sparingly,
+and instead logging levels should be used. It is included to make it easier
+for log aggregation services to key off.
+
+```golang
+func randoFunc(ctx context.Context) {
+    ...
+
+    // The same as
+    // golflog.Info(ctx, "message", "severity", "warning", "key", "value")
+    golflog.Warn(ctx, "message", "key", "value")
+}
+```
+
+`Warning` is an alias of `Warn`.
+
+```golang
+func randoFunc(ctx context.Context) {
+    ...
+
+    // The same as
+    // golflog.Info(ctx, "message", "severity", "warning", "key", "value")
+    golflog.Warning(ctx, "message", "key", "value")
+}
+```
+
 ### Env setup
 
 An alternative to calling `golflog.NewLogger` with the parameters, is to call

--- a/README.md
+++ b/README.md
@@ -101,14 +101,21 @@ func randoFunc(ctx context.Context, importantValue string) {
 ### Logging Convenience Helpers
 
 `Info` and `Error` convenience helpers are provided to log or report an error
-to the logger in the context.
+to the logger in the context. A `severity` key is added to each to invocation
+automatically to assist log aggregation services.
 
 ```golang
 func randoFunc(ctx context.Context) {
+    // Same as:
+    // log := golflog.AlwaysFromContext(ctx)
+    // log.Info("message", "severity", "info", "key", "value")
     golflog.Info(ctx, "message", "key", "value")
 
     ...
 
+    // Same as:
+    // log := golflog.AlwaysFromContext(ctx)
+    // log.Error(err, "message", "severity", "error", "key", "value")
     golflog.Error(ctx, err, "message", "key", "value")
 }
 ```

--- a/README.md
+++ b/README.md
@@ -167,6 +167,22 @@ func randoFunc(ctx context.Context) {
 }
 ```
 
+A `Debug` helper will automatically prepend `severity=debug` to the list of
+key/value pairs and logs out the message at a level 1 higher than the level
+of the logger in the `context.Context`. This helper should be used sparingly,
+and instead logging levels should be used. It is included to make it easier
+for log aggregation services to key off.
+
+```golang
+func randoFunc(ctx context.Context) {
+    ...
+
+    // The same as
+    // golflog.V(ctx, 1).Info("message", "severity", "warning", "key", "value")
+    golflog.Debug(ctx, "message", "key", "value")
+}
+```
+
 ### Env setup
 
 An alternative to calling `golflog.NewLogger` with the parameters, is to call

--- a/context_test.go
+++ b/context_test.go
@@ -192,7 +192,10 @@ func (suite *ContextWithNameAndValuesSuite) TestContextWithNameAndValues() {
 	ctx := golflog.ContextWithNameAndValues(context.TODO(), "test", "testkey", "testval")
 
 	golflog.Info(ctx, "test")
-	suite.Equal(`test "level"=0 "msg"="test" "testkey"="testval"`+"\n", buf.String())
+	suite.Equal(
+		`test "level"=0 "msg"="test" "testkey"="testval" "severity"="info"`+"\n",
+		buf.String(),
+	)
 }
 
 func TestContextWithNameAndValues(t *testing.T) {

--- a/log.go
+++ b/log.go
@@ -164,7 +164,7 @@ func V(ctx context.Context, level int) logr.Logger {
 	return logger.V(level)
 }
 
-// NOTE(jkoelker) The Warn/Warning helpers, should be used sparingly.
+// NOTE(jkoelker) The Warn/Warning and Debug helpers, should be used sparingly.
 
 // Warn gets a logger from the given context and logs the message with `severity=warning`
 // prepended into the passed key/value.
@@ -184,4 +184,15 @@ func Warning(ctx context.Context, message string, keysAndValues ...interface{}) 
 
 	ctx = NewContext(ctx, logger)
 	Warn(ctx, message, keysAndValues...)
+}
+
+// Debug get a logger from the given context at one level higher than the current level and log
+// the message. Prepends `severity=debug` to the passed key/value.
+func Debug(ctx context.Context, message string, keysAndValues ...interface{}) {
+	helper, logger := AlwaysFromContext(ctx).WithCallStackHelper()
+	helper()
+
+	// NOTE(jkoelker) prepend the severity to ensure it is correct if a single `keysAndValues`
+	//                argument is passed or an odd number.
+	logger.V(1).Info(message, append([]interface{}{"severity", "debug"}, keysAndValues...)...)
 }

--- a/log.go
+++ b/log.go
@@ -128,7 +128,9 @@ func Wrap(
 ) error {
 	helper, logger := AlwaysFromContext(ctx).WithCallStackHelper()
 	helper()
-	logger.Error(err, message, keysAndValues...)
+
+	ctx = NewContext(ctx, logger)
+	Error(ctx, err, message, keysAndValues...)
 
 	return fmt.Errorf("%s: %w", message, err)
 }
@@ -148,7 +150,8 @@ func Info(
 	logger.Info(message, append([]interface{}{"severity", "info"}, keysAndValues...)...)
 }
 
-// Error gets a logger from the given context and logs the error and message and optional values.
+// Error gets a logger from the given context and logs the error and message and optional values
+// with `severity=error` prepended into the passed key/value.
 func Error(
 	ctx context.Context,
 	err error,
@@ -157,7 +160,10 @@ func Error(
 ) {
 	helper, logger := AlwaysFromContext(ctx).WithCallStackHelper()
 	helper()
-	logger.Error(err, message, keysAndValues...)
+
+	// NOTE(jkoelker) prepend the severity to ensure it is correct if a single `keysAndValues`
+	//                argument is passed or an odd number.
+	logger.Error(err, message, append([]interface{}{"severity", "error"}, keysAndValues...)...)
 }
 
 // V gets a logger from the given context for the level specified.

--- a/log.go
+++ b/log.go
@@ -133,7 +133,8 @@ func Wrap(
 	return fmt.Errorf("%s: %w", message, err)
 }
 
-// Info gets a logger from the given context and logs message and optional values.
+// Info gets a logger from the given context and logs message and optional values with
+// `severity=info` prepended into the passed key/value.
 func Info(
 	ctx context.Context,
 	message string,
@@ -141,7 +142,10 @@ func Info(
 ) {
 	helper, logger := AlwaysFromContext(ctx).WithCallStackHelper()
 	helper()
-	logger.Info(message, keysAndValues...)
+
+	// NOTE(jkoelker) prepend the severity to ensure it is correct if a single `keysAndValues`
+	//                argument is passed or an odd number.
+	logger.Info(message, append([]interface{}{"severity", "info"}, keysAndValues...)...)
 }
 
 // Error gets a logger from the given context and logs the error and message and optional values.

--- a/log.go
+++ b/log.go
@@ -163,3 +163,25 @@ func V(ctx context.Context, level int) logr.Logger {
 
 	return logger.V(level)
 }
+
+// NOTE(jkoelker) The Warn/Warning helpers, should be used sparingly.
+
+// Warn gets a logger from the given context and logs the message with `severity=warning`
+// prepended into the passed key/value.
+func Warn(ctx context.Context, message string, keysAndValues ...interface{}) {
+	helper, logger := AlwaysFromContext(ctx).WithCallStackHelper()
+	helper()
+
+	// NOTE(jkoelker) prepend the severity to ensure it is correct if a single `keysAndValues`
+	//                argument is passed or an odd number.
+	logger.Info(message, append([]interface{}{"severity", "warning"}, keysAndValues...)...)
+}
+
+// Warning is an alias of the `Warn` function.
+func Warning(ctx context.Context, message string, keysAndValues ...interface{}) {
+	helper, logger := AlwaysFromContext(ctx).WithCallStackHelper()
+	helper()
+
+	ctx = NewContext(ctx, logger)
+	Warn(ctx, message, keysAndValues...)
+}

--- a/log_test.go
+++ b/log_test.go
@@ -229,14 +229,14 @@ func (suite *InfoSuite) TearDownTest() {
 	suite.configurator.AssertExpectations(suite.T())
 }
 
-func (suite *InfoSuite) TestWrap() {
+func (suite *InfoSuite) TesInfo() {
 	buf, logger := bufferLogger()
 
 	ctx := golflog.NewContext(context.TODO(), logger)
 
 	golflog.Info(ctx, "message", "key", "value")
 
-	suite.Equal(`"level"=0 "msg"="message" "key"="value"`, buf.String())
+	suite.Equal(`"level"=0 "msg"="message" "severity"="info" "key"="value"`, buf.String())
 }
 
 func TestInfo(t *testing.T) {

--- a/log_test.go
+++ b/log_test.go
@@ -336,3 +336,31 @@ func (suite *WarnSuite) TestWarning() {
 func TestWarn(t *testing.T) {
 	suite.Run(t, new(WarnSuite))
 }
+
+type DebugSuite struct {
+	suite.Suite
+
+	configurator *mocks.Configurator
+}
+
+func (suite *DebugSuite) SetupTest() {
+	suite.configurator = &mocks.Configurator{}
+}
+
+func (suite *DebugSuite) TearDownTest() {
+	suite.configurator.AssertExpectations(suite.T())
+}
+
+func (suite *DebugSuite) TestDebug() {
+	buf, logger := bufferLogger()
+
+	ctx := golflog.NewContext(context.TODO(), logger)
+
+	golflog.Debug(ctx, "message", "key", "value")
+
+	suite.Equal(`"level"=1 "msg"="message" "severity"="debug" "key"="value"`, buf.String())
+}
+
+func TestDebug(t *testing.T) {
+	suite.Run(t, new(DebugSuite))
+}

--- a/log_test.go
+++ b/log_test.go
@@ -298,3 +298,41 @@ func (suite *VSuite) TestV() {
 func TestV(t *testing.T) {
 	suite.Run(t, new(VSuite))
 }
+
+type WarnSuite struct {
+	suite.Suite
+
+	configurator *mocks.Configurator
+}
+
+func (suite *WarnSuite) SetupTest() {
+	suite.configurator = &mocks.Configurator{}
+}
+
+func (suite *WarnSuite) TearDownTest() {
+	suite.configurator.AssertExpectations(suite.T())
+}
+
+func (suite *WarnSuite) TestWarn() {
+	buf, logger := bufferLogger()
+
+	ctx := golflog.NewContext(context.TODO(), logger)
+
+	golflog.Warn(ctx, "message", "key", "value")
+
+	suite.Equal(`"level"=0 "msg"="message" "severity"="warning" "key"="value"`, buf.String())
+}
+
+func (suite *WarnSuite) TestWarning() {
+	buf, logger := bufferLogger()
+
+	ctx := golflog.NewContext(context.TODO(), logger)
+
+	golflog.Warning(ctx, "message", "key", "value")
+
+	suite.Equal(`"level"=0 "msg"="message" "severity"="warning" "key"="value"`, buf.String())
+}
+
+func TestWarn(t *testing.T) {
+	suite.Run(t, new(WarnSuite))
+}

--- a/log_test.go
+++ b/log_test.go
@@ -207,7 +207,7 @@ func (suite *WrapSuite) TestWrap() {
 
 	err := golflog.Wrap(ctx, errors.New("test"), "message", "key", "value")
 
-	suite.Equal(`"msg"="message" "error"="test" "key"="value"`, buf.String())
+	suite.Equal(`"msg"="message" "error"="test" "severity"="error" "key"="value"`, buf.String())
 	suite.ErrorContains(err, "message: test")
 }
 
@@ -264,7 +264,7 @@ func (suite *ErrorSuite) TestError() {
 
 	golflog.Error(ctx, errors.New("test"), "message", "key", "value")
 
-	suite.Equal(`"msg"="message" "error"="test" "key"="value"`, buf.String())
+	suite.Equal(`"msg"="message" "error"="test" "severity"="error" "key"="value"`, buf.String())
 }
 
 func TestError(t *testing.T) {


### PR DESCRIPTION
* Adds `Warn`/`Warning` helpers
* Add a `Debug` helper

These helpers will automatically add in `severity=` key with the value `warning` or `debug` so log aggregators like DataDog can use it to split out the message and categorize it.

